### PR TITLE
Fix rendering functions after a recent change in shr-heading.

### DIFF
--- a/devdocs-browser.el
+++ b/devdocs-browser.el
@@ -176,16 +176,16 @@ See https://prismjs.com/ for list of language names."
 (defun devdocs-browser--eww-tag-h2 (dom)
   "Rendering function for h2 DOM.  Maybe use it as title."
   (devdocs-browser--eww-tag-maybe-set-title dom)
-  (shr-heading dom (if shr-use-fonts
-                       '(variable-pitch (:height 1.2 :weight bold))
-                     'bold)))
+  (apply #'shr-heading dom (if shr-use-fonts
+                               '(variable-pitch 1.2 bold)
+                             '(bold))))
 
 (defun devdocs-browser--eww-tag-h3 (dom)
   "Rendering function for h2 DOM.  Maybe use it as title."
   (devdocs-browser--eww-tag-maybe-set-title dom)
-  (shr-heading dom (if shr-use-fonts
-                       '(variable-pitch (:height 1.1 :weight bold))
-                     'bold)))
+  (apply #'shr-heading dom (if shr-use-fonts
+                               '(variable-pitch 1.1 bold)
+                             '(bold))))
 
 (defun devdocs-browser--eww-tag-h4 (dom)
   "Rendering function for h4 DOM."


### PR DESCRIPTION
A recent change in "shr-heading"; https://github.com/emacs-mirror/emacs/commit/d41a5e4b1bafbb974d2c886d3198d9bda7821591, broke "devdocs-browser--eww-tag-h2" and "devdocs-browser--eww-tag-h3" when "shr-use-font-color" is t. This fixes that.

An alternative solution is to use the faces "shr-h2" and "shr-h3" instead. The benefit of that is that the user and the theme can customize those.